### PR TITLE
修复inser_aux中出现的内存泄漏问题.增加测试实例

### DIFF
--- a/TinySTL/Detail/Vector.impl.h
+++ b/TinySTL/Detail/Vector.impl.h
@@ -144,12 +144,16 @@ namespace TinySTL{
 		difference_type locationNeed = distance(first, last);//last - first;
 
 		if (locationLeft >= locationNeed){
-			iterator tempPtr = end() - 1;
-			for (; tempPtr - position >= 0; --tempPtr){//move the [position, finish_) back
-				//*(tempPtr + locationNeed) = *tempPtr;//bug
-				construct(tempPtr + locationNeed, *tempPtr);
+			if (finish_ - position > locationNeed){
+				TinySTL::uninitialized_copy(finish_ - locationNeed, finish_, finish_);
+				std::copy_backward(position, finish_ - locationNeed, finish_);
+				std::copy(first, last, position);
 			}
-			TinySTL::uninitialized_copy(first, last, position);
+			else{
+				iterator temp = TinySTL::uninitialized_copy(first + (finish_ - position), last, finish_);
+				TinySTL::uninitialized_copy(position, finish_, temp);
+				std::copy(first, first + (finish_ - position), position);
+			}
 			finish_ += locationNeed;
 		}
 		else{

--- a/TinySTL/Test/VectorTest.cpp
+++ b/TinySTL/Test/VectorTest.cpp
@@ -186,7 +186,48 @@ namespace TinySTL{
 			assert(!(foo == bar));
 			assert(foo != bar);
 		}
+		
+		class TestItem
+		{
+		public:
+			TestItem()
+			{
+				++count;
+			}
+			TestItem(const TestItem & other)
+			{
+				++count;
+			}
 
+			virtual ~TestItem()
+			{
+				--count;
+			}
+
+			static int getCount()
+			{
+				return count;
+			}
+		private:
+			static int count;
+		};
+		int TestItem::count = 0;
+
+		void testCase15()
+		{
+			assert(TestItem::getCount() == 0);
+			{
+				typedef TinySTL::vector<TestItem> TVector;
+				TVector t(10);
+				t.push_back(TestItem());
+				t.push_back(TestItem());
+				t.push_back(TestItem());
+				t.insert(t.begin(), t.begin(), t.begin() + 1);
+
+			}
+			assert(TestItem::getCount() == 0);
+
+		}
 
 		void testAllCases(){
 			testCase1();
@@ -203,6 +244,7 @@ namespace TinySTL{
 			testCase12();
 			testCase13();
 			testCase14();
+			testCase15();
 		}
 	}
 }


### PR DESCRIPTION
插入点之后的元素后撤需要考虑两种情况,1. 只需要调用operator ==(在元素和元素之间)2, 需要调用constructor
(在元素移动到裸内存上的时候).