### PR TITLE
correct erase/resize function in Vector

### DIFF
--- a/TinySTL/Detail/List.impl.h
+++ b/TinySTL/Detail/List.impl.h
@@ -395,7 +395,7 @@ namespace TinySTL{
 		auto node1 = lhs.head.p, node2 = rhs.head.p;
 		for (; node1 != lhs.tail.p && node2 != rhs.tail.p; node1 = node1->next, node2 = node2->next){
 			if (node1->data != node2->data)
-				break;
+				return false;
 		}
 		if (node1 == lhs.tail.p && node2 == rhs.tail.p)
 			return true;

--- a/TinySTL/Detail/String.cpp
+++ b/TinySTL/Detail/String.cpp
@@ -243,7 +243,9 @@ namespace TinySTL{
 	}
 	size_t string::find(const string& str, size_t pos) const{
 		size_t lengthOfS = str.size();
-		if (size() - pos < lengthOfS)
+		//if (size() - pos < lengthOfS)
+		//	return npos;
+		if (size() < lengthOfS + pos)
 			return npos;
 		return find_aux(str.cbegin(), pos, lengthOfS, size());
 	}

--- a/TinySTL/Detail/String.cpp
+++ b/TinySTL/Detail/String.cpp
@@ -264,6 +264,7 @@ namespace TinySTL{
 	}
 	size_t string::rfind(char c, size_t pos) const{
 		pos = changeVarWhenEuqalNPOS(pos, size(), 1);
+		if (npos == pos) return npos;
 		for (auto cit = cbegin() + pos; cit >= cbegin(); --cit){
 			if (*cit == c)
 				return cit - cbegin();
@@ -290,10 +291,12 @@ namespace TinySTL{
 		//if (pos - 0 < lengthOfS)
 		//	return npos;
 		pos = changeVarWhenEuqalNPOS(pos, size(), 1);
+		if (npos == pos) return npos;
 		return rfind_aux(str.begin(), pos, lengthOfS, 0);
 	}
 	size_t string::rfind(const char* s, size_t pos) const{
 		pos = changeVarWhenEuqalNPOS(pos, size(), 1);
+		if (npos == pos) return npos;
 		return rfind(s, pos, strlen(s));
 	}
 	size_t string::rfind(const char* s, size_t pos, size_t n) const{
@@ -388,6 +391,7 @@ namespace TinySTL{
 	size_t string::find_last_of(const string& str, size_t pos) const{
 		pos = changeVarWhenEuqalNPOS(pos, size(), 1);
 		//return find_last_of(str.begin(), pos, pos + 1);
+		if (npos == pos) return npos;
 		return find_last_of(str.begin(), pos, str.size());
 	}
 	size_t string::find_last_of(const char* s, size_t pos) const{
@@ -414,11 +418,13 @@ namespace TinySTL{
 	size_t string::find_last_not_of(const string& str, size_t pos) const{
 		pos = changeVarWhenEuqalNPOS(pos, size(), 1);
 		//return find_last_not_of(str.begin(), pos, size());
+		if (npos == pos) return npos;
 		return find_last_not_of(str.begin(), pos, str.size());
 	}
 	size_t string::find_last_not_of(const char* s, size_t pos) const{
 		pos = changeVarWhenEuqalNPOS(pos, size(), 1);
 		//return find_last_not_of(s, pos, pos + 1);
+		if (npos == pos) return npos;
 		return find_last_not_of(s, pos, strlen(s));
 	}
 	size_t string::find_last_not_of(const char* s, size_t pos, size_t n) const{

--- a/TinySTL/Detail/String.cpp
+++ b/TinySTL/Detail/String.cpp
@@ -382,7 +382,8 @@ namespace TinySTL{
 		return npos;
 	}
 	size_t string::find_first_not_of(char c, size_t pos) const{
-		for (size_t i = pos; i != size(); ++i){
+		//bug fix (if pos>size())
+		for (size_t i = pos; i < size(); ++i){ 
 			if ((*this)[i] != c)
 				return i;
 		}

--- a/TinySTL/Detail/Vector.impl.h
+++ b/TinySTL/Detail/Vector.impl.h
@@ -92,16 +92,10 @@ namespace TinySTL{
 	}
 	template<class T, class Alloc>
 	typename vector<T, Alloc>::iterator vector<T, Alloc>::erase(iterator first, iterator last){
-		//尾部残留对象数
-		difference_type lenOfTail = end() - last;
-		//删去的对象数目
-		difference_type lenOfRemoved = last - first;
-		finish_ = finish_ - lenOfRemoved;
-		for (; lenOfTail != 0; --lenOfTail){
-			auto temp = (last - lenOfRemoved);
-			*temp = *(last++);
-		}
-		return (first);
+		iterator pos = std::copy(last, finish_, first);
+		dataAllocator::destroy(pos, finish_);
+		finish_ = finish_ - (last - first);
+		return first;
 	}
 	template<class T, class Alloc>
 	template<class InputIterator>

--- a/TinySTL/Detail/Vector.impl.h
+++ b/TinySTL/Detail/Vector.impl.h
@@ -89,7 +89,12 @@ namespace TinySTL{
 	//***************修改容器的相关操作**************************
 	template<class T, class Alloc>
 	typename vector<T, Alloc>::iterator vector<T, Alloc>::erase(iterator position){
-		return erase(position, position + 1);
+		if (position + 1 != end())
+			std::copy(position + 1, finish_, position);
+		auto tmp = finish_;
+		--finish_;
+		dataAllocator::destroy(tmp);
+		return position;
 	}
 	template<class T, class Alloc>
 	typename vector<T, Alloc>::iterator vector<T, Alloc>::erase(iterator first, iterator last){

--- a/TinySTL/Detail/Vector.impl.h
+++ b/TinySTL/Detail/Vector.impl.h
@@ -63,7 +63,8 @@ namespace TinySTL{
 		}
 		else if (n > capacity()){
 			auto lengthOfInsert = n - size();
-			T *newStart = dataAllocator::allocate(getNewCapacity(lengthOfInsert));
+			//T *newStart = dataAllocator::allocate(getNewCapacity(lengthOfInsert));
+			T *newStart = dataAllocator::allocate(getNewCapacity(n));
 			T *newFinish = TinySTL::uninitialized_copy(begin(), end(), newStart);
 			newFinish = TinySTL::uninitialized_fill_n(newFinish, lengthOfInsert, val);
 


### PR DESCRIPTION
Vector：
1.  按照STL标准，我认为Vector中使用erase函数，需要对对象进行移位操作后，还需进行销毁操作。
故我对erase(iterator first, iterator last)进行了修改。
2.  erase(iterator position)函数中，原先操作为erase(position,position+1)，当
3.  position==finish,finish==end_of_storage情况下，position+1就不妥当了。
4. 在resize函数中，当n>size()时，需申请n个新空间，而不是申请(LengthOfInsert = n - capacity())个空间。

List：
1. 在重载==函数中，当数值不相等时可直接return false，不需要跳出循环再进行比较操作。
2. 如果两个List跳出循环时都是尾端，那么如此操作就会返回true，而不是正确值false。

String
1.  find函数中，如果if (size() - pos < lengthOfS)，注意此处size()返回的是size_t，如果size()<pos,则返回的数值极有可能大于 lengthOfS，所以修改为size() < lengthOfS + pos更为保险。
2.  使用changeVarWhenEuqalNPOS函数进行操作，得到数值需先进行npos==changeVarWhenEuqalNPOS(...)操作
